### PR TITLE
Feat/persistent default settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,31 @@
           "group": "b@2"
         }
       ]
+    },
+    "configuration": {
+      "title": "Font Awesome Gallery",
+      "properties": {
+        "vscode-fontawesome-gallery.defaultLabelType": {
+          "type": "string",
+          "enum": ["iconClassname", "iconUnicode"],
+          "enumDescriptions": [
+            "Show the icon class name (e.g. fa-house)",
+            "Show the icon unicode value (e.g. \\uf015)"
+          ],
+          "default": "iconClassname",
+          "description": "Default label type shown on icons. Can be overridden per-session using the sidebar menu buttons."
+        },
+        "vscode-fontawesome-gallery.defaultFaVersion": {
+          "type": "string",
+          "enum": ["v5", "v6"],
+          "enumDescriptions": [
+            "Font Awesome 5",
+            "Font Awesome 6"
+          ],
+          "default": "v6",
+          "description": "Default Font Awesome version to use. Can be overridden per-session using the sidebar menu buttons."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -16,7 +16,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       localResourceRoots: [this._extensionUri],
     };
 
-    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+    const config = vscode.workspace.getConfiguration('vscode-fontawesome-gallery');
+    const defaultLabelType = config.get<string>('defaultLabelType', 'iconClassname');
+    const defaultFaVersion = config.get<string>('defaultFaVersion', 'v6');
+
+    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, defaultLabelType, defaultFaVersion);
 
     webviewView.webview.onDidReceiveMessage(async (data) => {
       switch (data.command) {
@@ -38,7 +42,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     this._view = panel;
   }
 
-  private _getHtmlForWebview(webview: vscode.Webview) {
+  private _getHtmlForWebview(webview: vscode.Webview, defaultLabelType: string, defaultFaVersion: string) {
     const styleResetUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, "media", "reset.css")
     );
@@ -80,6 +84,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
           <link href="${fontawesomeV6CssUri}" rel="stylesheet">
 	  	</head>
         <body>
+           <script nonce="${nonce}">
+             window.defaultLabelType = ${JSON.stringify(defaultLabelType)};
+             window.defaultFaVersion = ${JSON.stringify(defaultFaVersion)};
+           </script>
            <script nonce="${nonce}" src="${scriptUri}"></script>
 	  	</body>
 	  </html>`;

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -36,6 +36,20 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         }
       }
     });
+
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (
+        e.affectsConfiguration('vscode-fontawesome-gallery.defaultLabelType') ||
+        e.affectsConfiguration('vscode-fontawesome-gallery.defaultFaVersion')
+      ) {
+        const cfg = vscode.workspace.getConfiguration('vscode-fontawesome-gallery');
+        webviewView.webview.html = this._getHtmlForWebview(
+          webviewView.webview,
+          cfg.get<string>('defaultLabelType', 'iconClassname'),
+          cfg.get<string>('defaultFaVersion', 'v6')
+        );
+      }
+    });
   }
 
   public revive(panel: vscode.WebviewView) {

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -37,19 +37,20 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       }
     });
 
-    vscode.workspace.onDidChangeConfiguration(e => {
+    const configListener = vscode.workspace.onDidChangeConfiguration(e => {
       if (
         e.affectsConfiguration('vscode-fontawesome-gallery.defaultLabelType') ||
         e.affectsConfiguration('vscode-fontawesome-gallery.defaultFaVersion')
       ) {
         const cfg = vscode.workspace.getConfiguration('vscode-fontawesome-gallery');
-        webviewView.webview.html = this._getHtmlForWebview(
-          webviewView.webview,
-          cfg.get<string>('defaultLabelType', 'iconClassname'),
-          cfg.get<string>('defaultFaVersion', 'v6')
-        );
+        webviewView.webview.postMessage({
+          command: 'updateDefaults',
+          defaultLabelType: cfg.get<string>('defaultLabelType', 'iconClassname'),
+          defaultFaVersion: cfg.get<string>('defaultFaVersion', 'v6'),
+        });
       }
     });
+    webviewView.onDidDispose(() => configListener.dispose());
   }
 
   public revive(panel: vscode.WebviewView) {

--- a/webviews/components/Sidebar.svelte
+++ b/webviews/components/Sidebar.svelte
@@ -44,6 +44,10 @@
       case "setFaVersion":
         setFaVersion(message.data);
         break;
+      case "updateDefaults":
+        window.defaultLabelType = message.defaultLabelType;
+        window.defaultFaVersion = message.defaultFaVersion;
+        break;
       default:
         break;
     }

--- a/webviews/components/Sidebar.svelte
+++ b/webviews/components/Sidebar.svelte
@@ -8,12 +8,12 @@
   let searchTerm = "";
   let categorySelector = "all";
   let gridType = vscode.getState()?.gridType || "grid";
-  let labelType = "iconClassname";
-  let faVersion = vscode.getState()?.faVersion || "v6";
+  let labelType = vscode.getState()?.labelType || window.defaultLabelType;
+  let faVersion = vscode.getState()?.faVersion || window.defaultFaVersion;
   let categoryList = getIconCategories(faVersion);
 
   $: {
-    vscode.setState({ gridType, faVersion });
+    vscode.setState({ gridType, faVersion, labelType });
 
     //Fetch Categories
     categoryList = getIconCategories(faVersion);

--- a/webviews/globals.d.ts
+++ b/webviews/globals.d.ts
@@ -9,6 +9,9 @@ declare global {
         getState: () => any;
         setState: (state: any) => void;
     }
+
+    var defaultLabelType: string;
+    var defaultFaVersion: string;
 }
 
 export {};


### PR DESCRIPTION
Adds two VS Code settings for persistent defaults:

- `vscode-fontawesome-gallery.defaultLabelType` — `iconClassname` (default) or `iconUnicode`
- `vscode-fontawesome-gallery.defaultFaVersion` — `v5` or `v6` (default)

Session choices (clicking the sidebar buttons) take priority over the setting. The setting kicks in on first load or when webview state is empty. Settings changes apply live without reloading the window.